### PR TITLE
Updates cli dependency org name

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/streadway/amqp"
 )
 


### PR DESCRIPTION
There was an org name switch in May 2016 which is currently served by a redirect.  This change updates the cli dependency to use the current org.