### PR TITLE
Add vhost parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Compiling
 
     go build
 
-That will produce the executible `rabbit-mq-stress-tester`
+That will produce the executable `rabbit-mq-stress-tester`
 
 Running
 -------
@@ -27,18 +27,19 @@ Running
 
 	GLOBAL OPTIONS:
 	   --server, -s 'rabbit-mq-test.cs1cloud.internal'	Hostname for RabbitMQ server
-	   --producer, -p '0'				Number of messages to produce, -1 to produce forever
-	   --port, -P 						Rabbitmq server port, default 5672
-	   --user, -u 						Rabbitmq username
-	   --password, --pass 		Rabbitmq password
-	   --wait, -w '0'					Number of nanoseconds to wait between publish events
-	   --consumer, -c '-1'				Number of messages to consume. 0 consumes forever
-	   --bytes, -b '0'					number of extra bytes to add to the RabbitMQ message payload. About 50K max
-	   --concurrency, -n '50'			number of reader/writer Goroutines
-	   --quiet, -q						Print only errors to stdout
-	   --wait-for-ack, -a				Wait for an ack or nack after enqueueing a message
-	   --version, -v					print the version
-	   --help, -h						show help
+	   --producer, -p '0'               Number of messages to produce, -1 to produce forever
+	   --port, -P                       Rabbitmq server port, default 5672
+	   --user, -u                       Rabbitmq username
+	   --password, --pass               Rabbitmq password
+	   --vhost 'my-vhost'               Rabbitmq vhost, default /
+	   --wait, -w '0'                   Number of nanoseconds to wait between publish events
+	   --consumer, -c '-1'              Number of messages to consume. 0 consumes forever
+	   --bytes, -b '0'                  number of extra bytes to add to the RabbitMQ message payload. About 50K max
+	   --concurrency, -n '50'           number of reader/writer Goroutines
+	   --quiet, -q                      Print only errors to stdout
+	   --wait-for-ack, -a               Wait for an ack or nack after enqueueing a message
+	   --version, -v                    print the version
+	   --help, -h                       show help
 
 Examples
 --------

--- a/main.go
+++ b/main.go
@@ -47,7 +47,11 @@ func runApp(c *cli.Context) {
 	println("Running!")
 	porto := "amqp://"
 	uri := porto + c.String("user") + ":" + c.String("password") + "@" + c.String("server") +
-		":" + c.String("port") + "/" + c.String("vhost")
+		":" + c.String("port")
+
+	if c.String("vhost") != "" {
+		uri += "/" + c.String("vhost")
+	}
 
 	if c.Int("consumer") > -1 {
 		makeConsumers(uri, c.Int("concurrency"), c.Int("consumer"))

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 		cli.StringFlag{Name: "server, s", Value: "rabbit-mq-test.cs1cloud.internal", Usage: "Hostname for RabbitMQ server"},
 		cli.StringFlag{Name: "port, P", Value: "5672", Usage: "Port for RabbitMQ server"},
 		cli.StringFlag{Name: "user, u", Value: "guest", Usage: "user for RabbitMQ server"},
-		cli.StringFlag{Name: "password, pass", Value: "guest", Usage: "user pasword for RabbitMQ server"},
+		cli.StringFlag{Name: "password, pass", Value: "guest", Usage: "user password for RabbitMQ server"},
 		cli.IntFlag{Name: "producer, p", Value: 0, Usage: "Number of messages to produce, -1 to produce forever"},
 		cli.IntFlag{Name: "wait, w", Value: 0, Usage: "Number of nanoseconds to wait between publish events"},
 		cli.IntFlag{Name: "consumer, c", Value: -1, Usage: "Number of messages to consume. 0 consumes forever"},

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 		cli.StringFlag{Name: "port, P", Value: "5672", Usage: "Port for RabbitMQ server"},
 		cli.StringFlag{Name: "user, u", Value: "guest", Usage: "user for RabbitMQ server"},
 		cli.StringFlag{Name: "password, pass", Value: "guest", Usage: "user password for RabbitMQ server"},
+		cli.StringFlag{Name: "vhost", Value: "", Usage: "vhost for RabbitMQ server"},
 		cli.IntFlag{Name: "producer, p", Value: 0, Usage: "Number of messages to produce, -1 to produce forever"},
 		cli.IntFlag{Name: "wait, w", Value: 0, Usage: "Number of nanoseconds to wait between publish events"},
 		cli.IntFlag{Name: "consumer, c", Value: -1, Usage: "Number of messages to consume. 0 consumes forever"},
@@ -45,7 +46,8 @@ func main() {
 func runApp(c *cli.Context) {
 	println("Running!")
 	porto := "amqp://"
-	uri := porto + c.String("user") + ":" + c.String("password") + "@" + c.String("server") + ":" + c.String("port")
+	uri := porto + c.String("user") + ":" + c.String("password") + "@" + c.String("server") +
+		":" + c.String("port") + "/" + c.String("vhost")
 
 	if c.Int("consumer") > -1 {
 		makeConsumers(uri, c.Int("concurrency"), c.Int("consumer"))


### PR DESCRIPTION
I wanted to use the stress-tester to create bad actors against specific vhosts.  This pull request adds a `--vhost` parameter to allow using something other than the default.