### PR TITLE
Added functionality for providing custom queue name while stress testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ Consume messages forever:
 	./tester -s rabbit-mq-test.cs1cloud.internal -c 0
 
 
-Produce 100,000 messages of 10KB each, using 50 concurrent goroutines, waiting 100 nanoseconds between each message. Only print to stdout if there is a nack or when you finish.
+Produce 100,000 messages of 10KB each to queue named `custom-queue-name`, using 50 concurrent goroutines, waiting 100 nanoseconds between each message. Only print to stdout if there is a nack or when you finish.
 
-	./tester -s rabbit-mq-test.cs1cloud.internal -p 100000 -b 10000 -w 100 -n 50 -q
+	./tester -s rabbit-mq-test.cs1cloud.internal -p 100000 -b 10000 -w 100 -n 50 -q --queue-name custom-queue-name

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Running
 	   --user, -u 						Rabbitmq username
 	   --password, --pass 		        Rabbitmq password
 	   --vhost, -V                      vhost for RabbitMQ server
+       --queue-name                     Name of the queue to `produce to` or `consume from`
 	   --producer, -p '0'				Number of messages to produce, -1 to produce forever
 	   --exchange, -x                   Name of exchange to send messages to
 	   --wait, -w '0'					Number of nanoseconds to wait between publish events

--- a/consumer.go
+++ b/consumer.go
@@ -13,6 +13,7 @@ type ConsumerConfig struct {
 	ThinkTime      int
 	ExchangeConfig ExchangeConfig
 	PrefetchCount  int
+	queueName string
 }
 
 func Consume(config ConsumerConfig, doneChan chan bool) {
@@ -35,7 +36,7 @@ func Consume(config ConsumerConfig, doneChan chan bool) {
 		}
 	}
 
-	q := MakeQueueAndBind(channel, config.ExchangeConfig)
+	q := MakeQueueAndBind(channel, config.ExchangeConfig, config.queueName)
 
 	msgs, err := channel.Consume(q.Name, "", config.ThinkTime == 0, false, false, false, nil)
 	if err != nil {
@@ -62,3 +63,4 @@ func Consume(config ConsumerConfig, doneChan chan bool) {
 	log.Println("done receiving")
 
 }
+

--- a/producer.go
+++ b/producer.go
@@ -15,6 +15,7 @@ type ProducerConfig struct {
 	Quiet          bool
 	WaitForAck     bool
 	ExchangeConfig ExchangeConfig
+	queueName string
 }
 
 func Produce(config ProducerConfig, tasks chan int, producerId int) {
@@ -34,8 +35,8 @@ func Produce(config ProducerConfig, tasks chan int, producerId int) {
 	}
 
 	ack, nack := channel.NotifyConfirm(make(chan uint64, 1), make(chan uint64, 1))
-
-	q := MakeQueueAndBind(channel, config.ExchangeConfig)
+	
+    q := MakeQueueAndBind(channel, config.ExchangeConfig, config.queueName)
 
 	for {
 
@@ -705,3 +706,4 @@ landojn de la tero, por ke iam ĉiuj eksentu ĝian benon.`
 	return longString[0:bytes]
 
 }
+


### PR DESCRIPTION
We can create multiple queues for stress testing by running it multiple times with different queue names. 